### PR TITLE
Shader 3.5 : Simplify lighting library

### DIFF
--- a/Assets/Refreshers/Shader/LightingFuncsUnity.cginc
+++ b/Assets/Refreshers/Shader/LightingFuncsUnity.cginc
@@ -1,0 +1,319 @@
+/*
+Same file as LightingFuncs.cginc but it used Unity naming convention 
+in order to leverage its standard macros. Done in order to simplify code 
+for future commits.
+*/
+
+
+#if !defined(HELIUM_LIGHTING_INCLUDED)
+#define HELIUM_LIGHTING_INCLUDED
+
+
+// cginc because it is an include file
+// #include "UnityCG.cginc" // Already included by UnityStandardBRDF
+// #include "UnityStandardBRDF.cginc" // in UnityPBSLighting
+// #include "UnityStandardUtils.cginc" // in UnityPBSLighting 
+#include "UnityPBSLighting.cginc"
+
+// Helper functions for lights. 
+// Here light falloff for the point light is computed by transforming coordinates
+// in the light's local space scaled by its attenuation. Anything further than 1
+// from the light is considered out of range and thus attenuation = 0.
+#include "AutoLight.cginc"
+
+// To prove TRANSFORM_TEX is just a define
+#define HELIUM_TRANSFORM_TEX(x,y) (x.xy * y##_ST.xy + y##_ST.zw)
+
+
+
+sampler2D _Tex;
+#ifdef HELIUM_HEIGHT_MAPPING
+sampler2D _Height;
+// e.g. resolution is 1000x2000 => texel size is u=1/1000, v  = 1/2000
+// the minimum amount of change for u and v that moves sampling to another pixel
+float4 _Height_TexelSize;
+#endif
+#ifdef HELIUM_NORMAL_MAPPING
+sampler2D _Normal, _SecondaryTex, _SecondaryNormal;
+float _NormalStrength,_SecondaryNormalStrength;
+float4 _SecondaryTex_ST;
+
+#endif
+#ifdef HELIUM_BASE_COLOR
+float4 _Color;
+#endif
+
+float4 _Tex_ST;
+
+float _Roughness, _Metallic;
+int _UseTextures;
+
+struct vInput{
+    /*
+    In order to use some Unity Macros, namely:
+    - UNITY_LIGHT_ATTENUATION
+    - SHADOW_ATTENUATION
+    - TRANSFER_SHADOW
+    - SHADOW_COORDS
+    We would need to rename "pos" to "vertex" as it is the name
+    of the field assuemd by the Unity macros. We will instead keep our own code.
+    This should cause the Spotlight shadows to break, but Unity fallsback to its own model.
+    */
+    float4 vertex: POSITION;
+    float3 n : NORMAL;
+    float2 uv : TEXCOORD0;
+
+    #ifdef HELIUM_NORMAL_MAPPING
+    float4 tan : TANGENT;
+    #endif
+};
+
+struct vOutput{
+
+    /*
+    In order to use some Unity Macros, namely:
+    - UNITY_LIGHT_ATTENUATION
+    - SHADOW_ATTENUATION
+    - TRANSFER_SHADOW
+    - SHADOW_COORDS
+    We needed to rename "csPos" to "pos" as it is the name
+    of the field assuemd by the Unity macros.
+    */
+    float4 pos : SV_Position; // Clip Space
+    float3 n :   TEXCOORD0;
+    #ifdef HELIUM_NORMAL_MAPPING
+    float4 uvM : TEXCOORD1; // Main(xy) and Secondary(zw)
+    #ifdef HELIUM_FRAGMENT_BINORMAL
+    float4 tan : TEXCOORD3;
+    #else
+    float4 tan : TEXCOORD3;
+    float3 bin : TEXCOORD4;
+    #endif
+    #else
+    float2 uvM : TEXCOORD1; // Main
+    #endif
+    float4 wPos : TEXCOORD2; // World Space Position
+
+    /*
+    Same as 
+    #ifdef SHADOWS_SCREEN
+    float4 _ShadowCoord : TEXCOORD5; //<--- NAME IS IMPORTANT
+    #endif
+    */
+    SHADOW_COORDS(5) // 5 for the index of TEXCOORD
+
+    #if defined(VERTEXLIGHT_ON)
+    float3 lColor: TEXCOORD6; // Computed vertex light
+    #endif
+
+};
+
+float3 ComputeBinormal(float3 n, float3 t, float sign){
+    return cross(n,t) * (sign * unity_WorldTransformParams.w/*Handles cases where object is mirrored in some dimension*/);
+}
+
+void ComputeVertexLight(inout vOutput v){
+    #if defined(VERTEXLIGHT_ON)
+    /*
+        float3 lPos = float3(
+            // unity_4LightPosA0 contains up to 4 vertex light information
+            // where A = coordinate of light (0 is always 0)
+            // X0.x => X coordinate of first light
+            // Z0.y => Z coordinate of second light etc...
+            unity_4LightPosX0.x,
+            unity_4LightPosY0.x,
+            unity_4LightPosZ0.x
+        );
+        float3 lv = lPos - v.wPos;
+        float3 lDir = normalize(lv);
+        float ndotl = DotClamped(v.n, lDir);
+        // unity_4LightAtten0 approximates attenuation of pixel lights.
+        // Essentialy aggregates overall attenuation
+        float dimming = 1 / (1 + (dot(lv, lv) * unity_4LightAtten0.x));
+      
+        v.lColor = unity_LightColor[0] * ndotl * dimming;
+    */
+        // Does what's written above for each of the 4 vertex lights supported
+        v.lColor = Shade4PointLights(
+            unity_4LightPosX0,          // x coordinates of the 4 lights
+            unity_4LightPosY0,          // y coordinates of the 4 lights
+            unity_4LightPosZ0,          // z coordinates of the 4 lights
+			unity_LightColor[0].rgb,    // Color light 1
+            unity_LightColor[1].rgb,    // Color light 2
+			unity_LightColor[2].rgb,    // Color light 3
+            unity_LightColor[3].rgb,    // Color light 4   
+			unity_4LightAtten0,         // Approximation of pixel lights
+            v.wPos,
+            v.n
+        );
+
+    #endif
+}
+
+vOutput vert(vInput i){
+    vOutput o;
+
+    o.uvM = 0;
+    o.uvM.xy = HELIUM_TRANSFORM_TEX(i.uv, _Tex);  // QOL command that summarizes texture tiling and offset
+    #ifdef HELIUM_NORMAL_MAPPING
+    o.uvM.zw = HELIUM_TRANSFORM_TEX(i.uv, _SecondaryTex);
+    o.tan = float4(UnityObjectToWorldDir(i.tan.xyz), i.tan.w);
+    #ifndef HELIUM_FRAGMENT_BINORMAL
+    o.bin = ComputeBinormal(i.n, i.tan.xyz, i.tan.w);
+    #endif
+
+    #endif
+    o.pos = UnityObjectToClipPos(i.vertex);
+    o.wPos = mul(unity_ObjectToWorld, i.vertex);
+
+    o.n = UnityObjectToWorldNormal(i.n); 
+    o.n = normalize(o.n);
+
+    // Check LightingFuncs.cginc to see deeper explanation of how this works
+    vInput v = i; // Unity assumes inpux from vertex shader is called v.
+    TRANSFER_SHADOW(o);
+    
+    ComputeVertexLight(o);
+    return o;
+}
+
+UnityIndirect CreateIndirectLightAndDeriveFromVertex(vOutput vo){
+    UnityIndirect il;
+    il.diffuse =0;
+    il.specular = 0;
+    #if defined(VERTEXLIGHT_ON)
+        il.diffuse = vo.lColor;
+    #endif
+    #if !defined(HELIUM_ADD_PASS)
+        il.diffuse += max(0, ShadeSH9(float4(vo.n, 1)));
+    #endif
+    return il;
+}
+
+UnityLight CreateLight(vOutput vo){
+    UnityLight l;
+    #if defined(POINT) || defined(SPOT) || defined(POINT_COOKIE)
+        float3 lVector =  _WorldSpaceLightPos0.xyz - vo.wPos;
+        l.dir = normalize( lVector);
+    #else
+        l.dir = _WorldSpaceLightPos0.xyz;
+    #endif
+    
+
+    // Check LightingFuncs.cginc to better see how this works
+    UNITY_LIGHT_ATTENUATION(dimming, vo, vo.wPos.xyz);
+
+    l.color = _LightColor0  * dimming;
+    // angle with surface normal
+    l.ndotl =  DotClamped(vo.n, _WorldSpaceLightPos0.xyz);
+    return l;
+}
+
+void InitFragNormal(inout vOutput vo){
+    #if defined(HELIUM_HEIGHT_MAPPING)
+    float2 du = float2(_Height_TexelSize.x * 0.5, 0);
+    float u1 = tex2D(_Height, vo.uvM - du);
+    float u2 = tex2D(_Height, vo.uvM + du);
+    float2 dv = float2(0, _Height_TexelSize.y * 0.5);
+    float v1 = tex2D(_Height, vo.uvM - dv);
+    float v2 = tex2D(_Height, vo.uvM + dv);
+
+    // Normal is the inverse of the tangent (rate of change)
+    vo.n = float3(u2-u1, 1 , v2-v1); // Temporary TODO: delete, only applicable to plane
+    vo.n = normalize(vo.n);
+    // Tangent space transformation
+    // float3 tv = float3(0, v2 - v1, 1);
+    // float3 tu = float3(1, u2 - u1, 0);
+    // float3x3 worldToTangent = transpose( float3x3(tu, tv, vo.n));
+    // vo.wPos  = float4(mul(worldToTan, vo.n),1);
+    #endif
+    #ifdef HELIUM_NORMAL_MAPPING
+
+    /*
+    vo.n.xy = tex2D(_Normal, vo.uvM).wy *2 -1;
+    vo.n.xy *= _NormalStrength;
+    vo.n.z = sqrt(1 - saturate(dot(vo.n.xy, vo.n.xy)));
+    */
+    // Same as previous 3 lines
+    float3 n1 = UnpackScaleNormal(tex2D(_Normal, vo.uvM.xy), -_NormalStrength); 
+    float3 n2 = UnpackScaleNormal(tex2D(_SecondaryNormal, vo.uvM.zw), -_SecondaryNormalStrength);
+    // Drawback of this approach is loss of detail for steeper slopers (the bigger the slope the greater the z thus the smaller weight in the addition)
+    // vo.n = float3(  // Break the two normals in their respective x and y derivative components, add those and recompute normal
+    //     vo.n.xy / vo.n.z + 
+    //     n2.xy / n2.z,
+    //     1
+    // ) 
+    // Use z instead as scaling factor
+    // This will behave the opposite of previous approach and normals will be stronger for steeper slopes.
+    // vo.n = float3(  // Break the two normals in their respective x and y derivative components, add those and recompute normal
+    //     vo.n.xy +
+    //     n2.xy,
+    //     vo.n.z * n2.z
+    // );
+    // Same as previous line (whiteout blending)
+    float3 tanSpaceNormal = BlendNormals(n1, n2);
+
+    // Normal maps store the up direction in the z component 
+    tanSpaceNormal = tanSpaceNormal.xzy;
+    #ifdef HELIUM_FRAGMENT_BINORMAL
+    float3 bn = ComputeBinormal(vo.n, vo.tan.xyz, vo.tan.w);
+    #else
+    float3 bn = vo.bin;
+    #endif
+    vo.n = normalize(
+        tanSpaceNormal.x * vo.tan + 
+        tanSpaceNormal.y * vo.n +
+        tanSpaceNormal.z * bn
+    );
+    #endif
+}
+
+float4 frag(vOutput vo): SV_Target{
+    float3 albedo =  tex2D(_Tex, vo.uvM.xy);
+
+
+    #ifdef HELIUM_BASE_COLOR
+    albedo *= _Color.xyz;
+    #endif
+
+    #if defined(HELIUM_HEIGHT_MAPPING) || defined(HELIUM_NORMAL_MAPPING)
+    InitFragNormal(vo);
+    #endif
+
+    #ifdef HELIUM_NORMAL_MAPPING
+
+    albedo *= tex2D(_SecondaryTex, vo.uvM.zw) * unity_ColorSpaceDouble;
+    #endif
+    
+    
+    float invertedReflectivity;
+    float3 specularColor;
+    // specularColor and invertedReflectivity are out parameters
+    albedo = DiffuseAndSpecularFromMetallic(
+        albedo, _Metallic, specularColor, invertedReflectivity
+        ); 
+        float3 viewdir = normalize(_WorldSpaceCameraPos - vo.wPos);
+        
+    #if !defined(HELIUM_HEIGHT_MAPPING)
+        vo.n = normalize(vo.n);
+    #endif
+    float3 approximatedCol = ShadeSH9(float4(vo.n, 1));
+    
+    UnityLight l = CreateLight(vo);
+    UnityIndirect il = CreateIndirectLightAndDeriveFromVertex(vo);
+    return UNITY_BRDF_PBS(
+    albedo,
+    specularColor,
+    invertedReflectivity,
+    1.0-_Roughness,
+    vo.n,
+    viewdir,
+    l,
+    il
+    );
+    // return finalDiffuse * albedo  /*Corrects linear to gamma transformation*/;
+}
+
+
+
+#endif

--- a/Assets/Refreshers/Shader/StdShadowUnity.mat
+++ b/Assets/Refreshers/Shader/StdShadowUnity.mat
@@ -7,8 +7,8 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: RefresherShadows
-  m_Shader: {fileID: 4800000, guid: 03921a2d5f1f744838650dc01ec9404c, type: 3}
+  m_Name: StdShadowUnity
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
@@ -43,10 +43,6 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - _Height:
-        m_Texture: {fileID: 2800000, guid: b1018c9c32b8c43c7a8070b2901bb0db, type: 3}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
     - _MainTex:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
@@ -55,27 +51,11 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - _Normal:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
     - _OcclusionMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _ParallaxMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _SecondaryNormal:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _SecondaryTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _Tex:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -88,21 +68,17 @@ Material:
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1
-    - _Metallic: 0.788
+    - _Metallic: 0
     - _Mode: 0
-    - _NormalStrength: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
-    - _Roughness: 0.753
-    - _SecondaryNormalStrength: 1
-    - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 1, g: 0, b: 0.18823528, a: 0}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
   m_BuildTextureStacks: []
   m_AllowLocking: 1

--- a/Assets/Refreshers/Shader/StdShadows.shader
+++ b/Assets/Refreshers/Shader/StdShadows.shader
@@ -1,0 +1,105 @@
+// Same as ShadowsPBShader but uses Unity naming convention
+Shader "Refreshers/ShadowsPBStandard"
+{
+    Properties{
+        _Color("Color", Color) = (1,1,1,1)
+        _Tex ("Texture", 2D) = "white" {}
+        [NoScaleOffset] _Normal ("Normal map", 2D) = "bump" {}
+        _NormalStrength("Normal Strength", Float) = 1
+        _SecondaryTex("Secondary Texture", 2D) = "gray"{}
+        [NoScaleOffset] _SecondaryNormal("Secondary Normal map", 2D) = "bump" {}
+        _SecondaryNormalStrength("Secondary Normal Strength", Float) = 1
+        _Roughness("Roughness", Range(0,1)) = 0.5
+        _Metallic("Metallic", Range(0,1)) = 0.1
+    }
+    CGINCLUDE
+    #define HELIUM_FRAGMENT_BINORMAL
+    ENDCG
+    SubShader{
+
+        Pass{
+            Tags {
+				"LightMode" = "ForwardBase"
+			}
+            CGPROGRAM
+            #pragma target 3.0 // to enable BRDF
+            #pragma vertex vert
+            #pragma fragment frag
+            
+            // Compile a version that computes light per vertex, much cheaper than per fragment.
+            // Only point is supported
+            #pragma multi_compile _ VERTEXLIGHT_ON
+
+			#pragma multi_compile _ SHADOWS_SCREEN 
+
+            #define HELIUM_NORMAL_MAPPING
+            #define HELIUM_BASE_COLOR
+        
+            #pragma multi_compile_fwdadd_fullshadows // equivalent of the following
+            // #pragma multi_compile DIRECTIONAL POINT SPOT DIRECTIONAL_COOKIE POINT_COOKIE
+
+			#include "LightingFuncsUnity.cginc"
+
+
+            ENDCG
+        }
+
+        Pass{
+            Tags{
+                "LightMode" = "ForwardAdd" // ForwardAdd makes it so this pass is "added" on top of the base one, used for the main light
+            }
+            // In this case Blend 0 One One is the same as Blend One One 
+            // since this shader is not using the other targets.
+            Blend 0 One One 
+            // In forward rendering, we only use the first (0 through 7) 
+            // render target for the "main color" which would be the final look of a rendered image.
+            // In deferred, all the targets are used for different things: 0 = Albedo, 1 = Normals etc.... 
+            // So each element in the frame buffer would contain different info. 
+            
+            // Do not check and write to zbuffer as the depth check has been already run 
+            // in the base pass.
+            ZWrite Off 
+
+            CGPROGRAM
+            #pragma target 3.0 // to enable BRDF
+            
+            // Tells Unity's lighting helper 
+            // functions that all macros will compute lighting based on the point light model
+            // multi compile will create two compilations, 
+            // one with #define POINT
+            // and one with #define DIRECTIONAL
+            // and one with #define SPOT
+            // etc...
+            //#pragma multi_compile DIRECTIONAL POINT SPOT DIRECTIONAL_COOKIE POINT_COOKIE
+            // Equivalent of the one above
+            #pragma multi_compile_fwdadd_fullshadows
+            
+            #define HELIUM_NORMAL_MAPPING
+            #define HELIUM_ADD_PASS
+            
+            #pragma vertex vert
+            #pragma fragment frag
+            
+			#include "LightingFuncsUnity.cginc"
+            ENDCG
+            
+
+        }
+        Pass{
+            Tags{
+                "LightMode" = "ShadowCaster"
+            }
+            CGPROGRAM
+            #pragma target 3.0
+            #pragma vertex shadowVert
+            #pragma fragment shadowFrag
+
+            #pragma multi_compile_shadowcaster
+            
+            #include "ShadowFuncs.cginc"
+
+            ENDCG
+        }
+    }
+    Fallback "Diffuse"
+}


### PR DESCRIPTION
The lighting library is becoming quite complex.
Standardize names to follow Unity's convention and leverage its macros to reduce the code size from now on.
This will be used in future for future features (Reflections etc... ) so that the code can focus on that instead of being dispersive with its comments.