### PR TITLE
Vulkan 1.4 : Use local-only memory for vertex reading

### DIFF
--- a/Vulkan/main.h
+++ b/Vulkan/main.h
@@ -133,7 +133,9 @@ private:
     void createRenderPass();
     void createPipeline();
     void createFramebuffers();
+    void bufferCopy(VkBuffer src, VkBuffer dst, VkDeviceSize size);
     void createCommandPool();
+    void createAndBindDeviceBuffer( VkDeviceSize bufferSize, VkBufferUsageFlags bufferUsage, VkMemoryPropertyFlags propertyFlags, VkBuffer& buffer, VkDeviceMemory& bufferMemory);
     void createDeviceVertexBuffer();
     void createCommandBuffers();
     void recordCommandBuffer(VkCommandBuffer buffer, uint32_t swapchainImageIndex);


### PR DESCRIPTION
Do not use a host consistent buffer for the vertex buffer, to avoid latency issues with the device.
NB: Ideally speaking we should be using an allocator that manages one allocation for multiple buffers as the max number of concurrent `VkAllocateMemory` calls can be as low as 4096. So the ideal solution would be an allocator layer which does one `VkAllocateMemory` at max possible size and then indexes through the allocated memory to retrieve the needed buffer. 