### PR TITLE
Vulkan 1.5: Vertex Indexing support

### DIFF
--- a/Vulkan/main.cpp
+++ b/Vulkan/main.cpp
@@ -66,7 +66,9 @@ void HelloTriangleApplication::initVulkan() {
     std::cout<< "created command pool" << std::endl;
     #ifdef HELIUM_VERTEX_BUFFERS
     createDeviceVertexBuffer();
-    std::cout << "bound vertex buffers" << std::endl;
+    std::cout << "creates and bound vertex buffers" << std::endl;
+    createDeviceIndexBuffer();
+    std::cout << "created and bound index buffers" << std::endl;
     #endif
     createCommandBuffers();
     std::cout<< "created command buffers" << std::endl;
@@ -86,8 +88,11 @@ void HelloTriangleApplication::mainLoop() {
 
 void HelloTriangleApplication::cleanup() {
     destroySwapChain();
+
     vkDestroyBuffer(logiDevice, vertexBuffer, nullptr);
     vkFreeMemory(logiDevice, vertexBufferMemory, nullptr);
+    vkDestroyBuffer(logiDevice, indexBuffer, nullptr);
+    vkFreeMemory(logiDevice, indexBufferMemory, nullptr);
 
     vkDestroyPipeline(logiDevice, gPipeline, nullptr);
     vkDestroyPipelineLayout(logiDevice, pipelineLayout, nullptr);

--- a/Vulkan/main.h
+++ b/Vulkan/main.h
@@ -78,6 +78,9 @@ private:
     VkBuffer vertexBuffer;
     VkDeviceMemory vertexBufferMemory;
 
+    VkBuffer indexBuffer;
+    VkDeviceMemory indexBufferMemory;
+
     // Each image in the swap chain should have a framebuffer associated to it.
     std::vector<VkFramebuffer> swapchainFramebuffers;
 
@@ -136,9 +139,12 @@ private:
     void bufferCopy(VkBuffer src, VkBuffer dst, VkDeviceSize size);
     void createCommandPool();
     void createAndBindDeviceBuffer( VkDeviceSize bufferSize, VkBufferUsageFlags bufferUsage, VkMemoryPropertyFlags propertyFlags, VkBuffer& buffer, VkDeviceMemory& bufferMemory);
-    void createDeviceVertexBuffer();
     void createCommandBuffers();
     void recordCommandBuffer(VkCommandBuffer buffer, uint32_t swapchainImageIndex);
+    #ifdef HELIUM_VERTEX_BUFFERS
+    void createDeviceVertexBuffer();
+    void createDeviceIndexBuffer();
+    #endif
 
 
     //-------------------------------device_specs.cpp
@@ -187,8 +193,15 @@ struct Vert{
 };
 
 const std::vector<Vert> vertices = {
-    {{0.0f, -0.5f}, {1.0f, 1.0f, 1.0f}},
-    {{0.5f, 0.5f}, {0.0f, 1.0f, 0.0f}},
-    {{-0.5f, 0.5f}, {0.0f, 0.0f, 1.0f}}
+    {{-0.5f, -0.5f}, {1.0f, 0.0f, 0.0f}},
+    {{0.5f, -0.5f}, {0.0f, 1.0f, 0.0f}},
+    {{0.5f, 0.5f}, {0.0f, 0.0f, 1.0f}},
+    {{-0.5f, 0.5f}, {1.0f, 1.0f, 1.0f}}
 };
+
+const std::vector<uint16_t> indices = {
+    0, 1, 2,
+    2, 3, 0
+};
+
 #endif


### PR DESCRIPTION
Improve mem reutilization. 
Tip: Use custom allocator for buffers and the vulkan api to index through the buffer, this way we can pack multiple buffers into one, thus improving data locality and allocations. 